### PR TITLE
Fix missed timestamp on dmesg line of a multi-line message

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+PREFIX = /usr
+
 ifneq ($(DEB_HOST_MULTIARCH),)
 	CROSS_COMPILE ?= $(DEB_HOST_MULTIARCH)-
 endif
@@ -40,10 +42,10 @@ endif
 all : $(APP_BIN)
 
 $(APP_BIN): $(COMMON_OBJS) $(BUILD_DIR)/src/main.cpp.o
-	${CXX} -o $(BUILD_DIR)/$@ $^ $(LDFLAGS)
+	$(CXX) -o $(BUILD_DIR)/$@ $^ $(LDFLAGS)
 
 $(BUILD_DIR)/%.c.o: %.c
-	${CC} -c $< -o $@ ${CFLAGS}
+	$(CC) -c $< -o $@ $(CFLAGS)
 
 $(BUILD_DIR)/%.cpp.o: %.cpp
 	mkdir -p $(dir $@)
@@ -53,4 +55,4 @@ clean :
 	rm -rf $(BUILD_DIR)
 
 install:
-	install -D -m 0755  $(BUILD_DIR)/$(APP_BIN) $(DESTDIR)/usr/bin/$(APP_BIN)
+	install -Dm0755 $(BUILD_DIR)/$(APP_BIN) -t $(DESTDIR)$(PREFIX)/bin

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-logs (1.4.5) stable; urgency=medium
+
+  * Fix missed timestamp on dmesg line of a multi-line message
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Fri, 19 Apr 2024 09:45:00 +0400
+
 wb-mqtt-logs (1.4.4) stable; urgency=medium
 
   * Add arm64 build, no functional changes

--- a/src/log_reader.cpp
+++ b/src/log_reader.cpp
@@ -177,7 +177,7 @@ namespace
     Json::Value GetDmesgLogs(std::chrono::system_clock::time_point bootTime)
     {
         Json::Value res(Json::arrayValue);
-        for (const auto& s: ExecCommand("dmesg --color=never")) {
+        for (const auto& s: ExecCommand("dmesg --color=never --force-prefix")) {
             Json::Value entry;
             size_t p = 0;
             if (s[0] == '[') {


### PR DESCRIPTION
В продолжение #9

В dmesg логе могут встречаться такие многострочные сообщения:
```sh
[    8.433896] RTW: [HALMAC]135
               HALMAC_MAJOR_VER = 1
               HALMAC_PROTOTYPE_VER = 6
               HALMAC_MINOR_VER = 6
               HALMAC_PATCH_VER = 39
```

Сейчас wb-mqtt-logs распарсит каждую строку отдельно, но только первая с таймстемпом. Как следствие это ломает сохранение лога в UI.

Это позволяет добавить timestamp ко всем строкам:
>        -p, --force-prefix
>            Add facility, level or timestamp information to each line of
>            a multi-line message.

```diff
@@ -392,10 +392,10 @@
 [    8.407432] Bluetooth: hci0: RTL: examining hci_ver=08 hci_rev=000f lmp_ver=08 lmp_subver=8723
 [    8.424173] usbcore: registered new interface driver btusb
 [    8.433896] RTW: [HALMAC]135
-               HALMAC_MAJOR_VER = 1
-               HALMAC_PROTOTYPE_VER = 6
-               HALMAC_MINOR_VER = 6
-               HALMAC_PATCH_VER = 39
+[    8.433896] HALMAC_MAJOR_VER = 1
+[    8.433896] HALMAC_PROTOTYPE_VER = 6
+[    8.433896] HALMAC_MINOR_VER = 6
+[    8.433896] HALMAC_PATCH_VER = 39
 [    8.598962] RTW: hal_com_config_channel_plan chplan:0x7F
 [    8.635298] Bluetooth: hci0: RTL: examining hci_ver=08 hci_rev=000f lmp_ver=08 lmp_subver=8723
 [    8.644005] Bluetooth: hci0: RTL: unknown IC info, lmp subver 8723, hci rev 000f, hci ver 0008
```

Note: в более свежих версиях util-linux dmesg умеет с `--json` возвращать сразу json. Можно будет избавиться от парсинга.