### PR TITLE
Fix uninitialized variable

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-logs (1.4.7) stable; urgency=medium
+
+  * Fix uninitialized variable
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Wed, 24 Jul 2024 16:45:00 +0400
+
 wb-mqtt-logs (1.4.6) stable; urgency=medium
 
   * Fix dmesg log filtering

--- a/src/log_reader.cpp
+++ b/src/log_reader.cpp
@@ -122,7 +122,7 @@ namespace
         bool Backward = true;
         std::string Service;
         uint32_t MaxEntries = MAX_LOG_RECORDS;
-        std::chrono::microseconds From;
+        std::chrono::microseconds From = std::chrono::microseconds::zero();
         std::string Cursor;
         UnicodeString Pattern;
         bool CaseSensitive = true;


### PR DESCRIPTION
How to reproduce:
* wb7
```sh
$ mqtt-rpc-client -d wb_logs -s logs -m List | jq '.boots[0].hash'
537b43535faf4f839b4b8efa5bc6ec93
$ mqtt-rpc-client -d wb_logs -s logs -m Load -a '{"service": "mosquitto.service", "boot": "537b43535faf4f839b4b8efa5bc6ec93", "limit": 1}' | jq 'length'
1
```
* wb8
```sh
$ mqtt-rpc-client -d wb_logs -s logs -m List | jq '.boots[0].hash'
abd988f3fcc3441da8d4cccfc5d56a68
$ mqtt-rpc-client -d wb_logs -s logs -m Load -a '{"service": "mosquitto.service", "boot": "abd988f3fcc3441da8d4cccfc5d56a68", "limit": 1}' | jq 'length'
0
```

The reason is that uninitialized std::chrono::microseconds variable:
* 281473554839088 on wb8
* -5264104641750106111 on wb7

But compared with 0 in https://github.com/wirenboard/wb-mqtt-logs/blob/2933d63ff102f6e50b7983620b5f2e8c90b3690b/src/log_reader.cpp#L343