### PR TITLE
Fix services list

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-logs (1.5.0) stable; urgency=medium
+
+  * Fix services list
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Fri, 31 Jan 2025 19:00:00 +0400
+
 wb-mqtt-logs (1.4.8) stable; urgency=medium
 
   * Add dependency from libwbmqtt1-5. No functional changes

--- a/debian/control
+++ b/debian/control
@@ -14,3 +14,4 @@ Package: wb-mqtt-logs
 Architecture: any
 Depends: ${shlibs:Depends}, ${misc:Depends}
 Description: Wiren Board journald to MQTT gateway
+ wb-mqtt-logs is a service which provides access to logs from journald via MQTT.

--- a/src/log_reader.cpp
+++ b/src/log_reader.cpp
@@ -90,7 +90,7 @@ namespace
         const char* servicePostfix = ".service";
         const auto servicePostfixLen = strlen(servicePostfix);
         Json::Value res(Json::arrayValue);
-        auto services = ExecCommand("systemctl list-unit-files *.service");
+        auto services = ExecCommand("systemctl list-units --type=service --state=loaded --no-pager --plain");
         for (const auto& service: services) {
             auto pos = service.find(servicePostfix);
             if (pos != std::string::npos) {


### PR DESCRIPTION
* List actual units instead of template unit files (e.g. `wb-cloud-agent@.service` -> `wb-cloud-agent@staging.service`)
* Dont's list aliases (e.g. `wb-homa-gpio.service` is an alias for `wb-mqtt-gpio.service`, `dbus-org.freedesktop.ModemManager1` is an alias for `ModemManager.service`)

Diff of `mqtt-rpc-client -d wb_logs -s logs -m List | jq -r '.services[]'` output before and after the fix:
```diff
--- before.log	2025-02-02 16:14:52.201733282 +0000
+++ after.log	2025-02-02 16:24:19.099985065 +0000
@@ -1,126 +1,77 @@
 apparmor.service
 apt-daily-upgrade.service
 apt-daily.service
-autovt@.service
 avahi-daemon.service
 bluetooth.service
-console-getty.service
-container-getty@.service
 containerd.service
 cron.service
-cryptdisks-early.service
-cryptdisks.service
-dbus-fi.w1.wpa_supplicant1.service
-dbus-org.bluez.service
-dbus-org.freedesktop.Avahi.service
-dbus-org.freedesktop.hostname1.service
-dbus-org.freedesktop.locale1.service
-dbus-org.freedesktop.login1.service
-dbus-org.freedesktop.ModemManager1.service
-dbus-org.freedesktop.nm-dispatcher.service
-dbus-org.freedesktop.timedate1.service
 dbus.service
-debug-shell.service
 dnsmasq.service
-dnsmasq@.service
 docker.service
-e2scrub@.service
 e2scrub_all.service
-e2scrub_fail@.service
 e2scrub_reap.service
 emergency.service
 fcgiwrap.service
 fstrim.service
 getty-static.service
-getty@.service
+getty@tty1.service
 hostapd.service
-hostapd@.service
-hwclock.service
-ifup@.service
 ifupdown-pre.service
-ifupdown-wait-online.service
 initrd-cleanup.service
 initrd-parse-etc.service
 initrd-switch-root.service
 initrd-udevadm-cleanup-db.service
 kmod-static-nodes.service
-kmod.service
 knxd.service
 logrotate.service
 man-db.service
 ModemManager.service
-modprobe@.service
+modprobe@dm_mod.service
+modprobe@drm.service
+modprobe@efi_pstore.service
+modprobe@fuse.service
+modprobe@loop.service
 mosquitto.service
 netplug.service
 networking.service
-NetworkManager-dispatcher.service
 NetworkManager-wait-online.service
 NetworkManager.service
-nftables.service
 nginx.service
-nm-priv-helper.service
 ntp.service
 polkit.service
-procps.service
-quotaon.service
 rc-local.service
-rc.service
-rcS.service
 rescue.service
 rsync.service
-serial-getty@.service
+serial-getty@ttyS0.service
 snmpd.service
 ssh.service
-ssh@.service
-sshd.service
-sudo.service
-system-update-cleanup.service
 systemd-ask-password-console.service
 systemd-ask-password-wall.service
-systemd-backlight@.service
 systemd-binfmt.service
-systemd-boot-check-no-failures.service
-systemd-exit.service
 systemd-firstboot.service
 systemd-fsck-root.service
-systemd-fsck@.service
+systemd-fsck@dev-mmcblk0p6.service
+systemd-fsck@dev-mmcblk1p1.service
 systemd-fsckd.service
-systemd-halt.service
-systemd-hibernate-resume@.service
-systemd-hibernate.service
-systemd-hostnamed.service
-systemd-hybrid-sleep.service
 systemd-initctl.service
 systemd-journal-flush.service
 systemd-journald.service
-systemd-journald@.service
-systemd-kexec.service
-systemd-localed.service
 systemd-logind.service
 systemd-machine-id-commit.service
 systemd-modules-load.service
-systemd-network-generator.service
-systemd-networkd-wait-online.service
-systemd-networkd-wait-online@.service
 systemd-networkd.service
 systemd-pcrphase-initrd.service
 systemd-pcrphase-sysinit.service
 systemd-pcrphase.service
-systemd-poweroff.service
 systemd-pstore.service
 systemd-quotacheck.service
 systemd-random-seed.service
-systemd-reboot.service
 systemd-remount-fs.service
 systemd-repart.service
 systemd-rfkill.service
-systemd-suspend-then-hibernate.service
-systemd-suspend.service
 systemd-sysctl.service
 systemd-sysext.service
 systemd-sysusers.service
-systemd-time-wait-sync.service
-systemd-timedated.service
 systemd-tmpfiles-clean.service
 systemd-tmpfiles-setup-dev.service
 systemd-tmpfiles-setup.service
@@ -130,28 +81,22 @@
 systemd-update-utmp-runlevel.service
 systemd-update-utmp.service
 systemd-user-sessions.service
-systemd-volatile-root.service
 tailscaled.service
-udev.service
-usb_modeswitch@.service
-user-runtime-dir@.service
-user@.service
+user-runtime-dir@0.service
+user@0.service
 watchdog.service
 wb-cloud-agent-frpc.service
-wb-cloud-agent-frpc@.service
+wb-cloud-agent-frpc@staging.service
 wb-cloud-agent-telegraf.service
-wb-cloud-agent-telegraf@.service
+wb-cloud-agent-telegraf@staging.service
 wb-cloud-agent.service
-wb-cloud-agent@.service
+wb-cloud-agent@staging.service
 wb-configs-early.service
 wb-configs.service
 wb-connection-manager.service
 wb-device-manager.service
 wb-diag-collect.service
 wb-gsm.service
-wb-homa-adc.service
-wb-homa-gpio.service
-wb-homa-w1.service
 wb-hwconf-manager.service
 wb-init.service
 wb-knxd-config.service
@@ -177,11 +122,7 @@
 wb-usb-otg.service
 wb-watch-update.service
 wd_keepalive.service
-wpa_supplicant-nl80211@.service
-wpa_supplicant-wired@.service
 wpa_supplicant.service
-wpa_supplicant@.service
-x11-common.service
 z-way-server.service
 zbw_connect.service
 dmesg
```