### PR TITLE
Fix build with icu>=75

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ COMMON_SRCS := $(shell find $(SRC_DIRS) \( -name *.cpp -or -name *.c \) -and -no
 COMMON_OBJS := $(COMMON_SRCS:%=$(BUILD_DIR)/%.o)
 
 LDFLAGS = -lpthread -lwbmqtt1 -lsystemd -licuuc -licui18n
-CXXFLAGS = -std=c++14 -Wall -Werror -I$(SRC_DIRS) -DWBMQTT_COMMIT="$(GIT_REVISION)" -DWBMQTT_VERSION="$(DEB_VERSION)" -Wno-psabi
+CXXFLAGS = -std=c++17 -Wall -Werror -I$(SRC_DIRS) -DWBMQTT_COMMIT="$(GIT_REVISION)" -DWBMQTT_VERSION="$(DEB_VERSION)" -Wno-psabi
 
 ifeq ($(DEBUG),)
 	CXXFLAGS += -O3

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-logs (1.5.3) state; urgency=medium
+
+  * Fix build with icu>=75
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Mon, 08 Apr 2025 16:30:00 +0400
+
 wb-mqtt-logs (1.5.2) state; urgency=medium
 
   * Fix build with gcc14

--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: wb-mqtt-logs
 Maintainer: Wiren Board team <info@wirenboard.com>
 Section: misc
 Priority: optional
-Standards-Version: 3.9.2
+Standards-Version: 4.5.1
 Build-Depends: debhelper (>= 10), 
                pkg-config, 
                libwbmqtt1-5-dev,

--- a/src/log_reader.cpp
+++ b/src/log_reader.cpp
@@ -275,7 +275,12 @@ namespace
         }
         entry["msg"] = d;
         if (!entry.isMember("level")) {
-            (void)std::any_of(LibWbMqttLogLevels.begin(), LibWbMqttLogLevels.end(), [&](const auto& p) {
+            auto it=std::find_if(LibWbMqttLogLevels.begin(), LibWbMqttLogLevels.end(), [&](const auto& p) {
+            return StringStartsWith(d, p.first);
+            });
+            if (it != LibWbMqttLogLevels.end()) {
+               entry["level"] = it.second;
+            }
                 if (StringStartsWith(d, p.first)) {
                     entry["level"] = p.second;
                     return true;

--- a/src/log_reader.cpp
+++ b/src/log_reader.cpp
@@ -279,7 +279,7 @@ namespace
                 return StringStartsWith(d, p.first);
             });
             if (it != LibWbMqttLogLevels.end()) {
-                entry["level"] = it.second;
+                entry["level"] = it->second;
             }
         }
         return true;

--- a/src/log_reader.cpp
+++ b/src/log_reader.cpp
@@ -275,7 +275,7 @@ namespace
         }
         entry["msg"] = d;
         if (!entry.isMember("level")) {
-            std::any_of(LibWbMqttLogLevels.begin(), LibWbMqttLogLevels.end(), [&](const auto& p) {
+            (void)std::any_of(LibWbMqttLogLevels.begin(), LibWbMqttLogLevels.end(), [&](const auto& p) {
                 if (StringStartsWith(d, p.first)) {
                     entry["level"] = p.second;
                     return true;

--- a/src/log_reader.cpp
+++ b/src/log_reader.cpp
@@ -275,18 +275,12 @@ namespace
         }
         entry["msg"] = d;
         if (!entry.isMember("level")) {
-            auto it=std::find_if(LibWbMqttLogLevels.begin(), LibWbMqttLogLevels.end(), [&](const auto& p) {
-            return StringStartsWith(d, p.first);
+            auto it = std::find_if(LibWbMqttLogLevels.begin(), LibWbMqttLogLevels.end(), [&](const auto& p) {
+                return StringStartsWith(d, p.first);
             });
             if (it != LibWbMqttLogLevels.end()) {
-               entry["level"] = it.second;
+                entry["level"] = it.second;
             }
-                if (StringStartsWith(d, p.first)) {
-                    entry["level"] = p.second;
-                    return true;
-                }
-                return false;
-            });
         }
         return true;
     }


### PR DESCRIPTION
Debian 13 ships libicu 76.1 (Debian 11 - 67.1), ICU>=75 requires C++17 (see https://github.com/unicode-org/icu/releases/tag/release-75-rc).
Fix compilation error after enabling `-std=c++17`:
```sh
src/log_reader.cpp:278:24: error: ignoring return value of ‘bool std::any_of(_IIter, _IIter, _Predicate) [with _IIter = __gnu_cxx::__normal_iterator<const pair<__cxx11::basic_string<char>, int>*, vector<pair<__cxx11::basic_string<char>, int> > >; _Predicate = {anonymous}::AddMsg(sd_journal*, Json::Value&, const icu_76::UnicodeString&, bool, bool)::<lambda(const auto:2&)>]’, declared with attribute ‘nodiscard’ [-Werror=unused-result]
  278 |             std::any_of(LibWbMqttLogLevels.begin(), LibWbMqttLogLevels.end(), [&](const auto& p) {
      |             ~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  279 |                 if (StringStartsWith(d, p.first)) {
      |                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  280 |                     entry["level"] = p.second;
      |                     ~~~~~~~~~~~~~~~~~~~~~~~~~~
  281 |                     return true;
      |                     ~~~~~~~~~~~~
  282 |                 }
      |                 ~       
  283 |                 return false;
      |                 ~~~~~~~~~~~~~
  284 |             });
      |             ~~          
In file included from /usr/arm-linux-gnueabihf/include/c++/14/algorithm:61,
                 from src/log_reader.cpp:5:
/usr/arm-linux-gnueabihf/include/c++/14/bits/stl_algo.h:447:5: note: declared here
  447 |     any_of(_InputIterator __first, _InputIterator __last, _Predicate __pred)
      |     ^~~~~~
cc1plus: all warnings being treated as errors
```