### PR TITLE
UTC time in boot list request

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-logs (1.5.5) stable; urgency=medium
+
+  * Use UTC timestamps in boot list request
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Wed, 26 Nov 2025 16:30:00 +0400
+
 wb-mqtt-logs (1.5.4) stable; urgency=medium
 
   * Force cancel loading on system signals received

--- a/src/log_reader.cpp
+++ b/src/log_reader.cpp
@@ -79,7 +79,7 @@ namespace
     Json::Value GetBoots()
     {
         Json::Value res;
-        auto boots = ExecCommand("journalctl --utc --list-boots");
+        auto boots = ExecCommand("TZ=UTC journalctl --list-boots");
         std::reverse(boots.begin(), boots.end());
         for (const auto& boot: boots) {
             try {


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**
Если выставить любую таймзону, напр. `timedatectl set-timezone Asia/Yerevan`, то журнал ломается:

<img width="731" height="239" alt="Screen Shot 2025-11-27 at 01 43 14" src="https://github.com/user-attachments/assets/9ceeac00-5852-4c6b-aa51-58387a28d2a7" />

Так как в RPC ответе приходит `"boots":null, ...`.

Уже чинили тут https://github.com/wirenboard/wb-mqtt-logs/pull/6, но это не работает:
```sh
journalctl --utc --list-boots
IDX BOOT ID                          FIRST ENTRY                 LAST ENTRY
  0 db345d9f339846769e2629f7ae27bdd4 Tue 2025-11-25 18:54:29 +04 Thu 2025-11-27 02:18:00 +04
```
Так работает корректно:
```
TZ=UTC journalctl --list-boots
IDX BOOT ID                          FIRST ENTRY                 LAST ENTRY
  0 db345d9f339846769e2629f7ae27bdd4 Tue 2025-11-25 14:54:29 UTC Wed 2025-11-26 22:23:19 UTC
```
___________________________________
**Что поменялось для пользователей:**
Журнал работает даже если настроена таймзона

___________________________________
**Как проверял/а:**
на вб

