### PR TITLE
Fix order of dmesg log etries in RPC Load response

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-logs (1.5.6) stable; urgency=medium
+
+  * Fix order of dmesg log etries in RPC Load response
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Fri, 22 May 2026 16:30:00 +0400
+
 wb-mqtt-logs (1.5.5) stable; urgency=medium
 
   * Use UTC timestamps in boot list request

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,6 @@
 wb-mqtt-logs (1.5.6) stable; urgency=medium
 
-  * Fix order of dmesg log etries in RPC Load response
+  * Fix order of dmesg log entries in RPC Load response
 
  -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Fri, 22 May 2026 16:30:00 +0400
 

--- a/src/log_reader.cpp
+++ b/src/log_reader.cpp
@@ -228,9 +228,10 @@ namespace
         auto pattern = UnicodeString::fromUTF8(params.get("pattern", "").asString());
         auto caseSensitive = params.get("case-sensitive", true).asBool();
         auto regEx = params.get("regex", false).asBool();
+        auto logs = ExecCommand("dmesg --color=never --force-prefix");
 
-        for (const auto& s: ExecCommand("dmesg --color=never --force-prefix")) {
-            Json::Value entry(ParseDmesgLog(s, bootTime));
+        for (auto it = logs.rbegin(); it != logs.rend(); ++it) {
+            Json::Value entry(ParseDmesgLog(*it, bootTime));
 
             if (!pattern.isEmpty()) {
                 auto msg = UnicodeString::fromUTF8(entry["msg"].asString());


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**
Порядок dmesg лога был в обратном направлении по сравнению с остальными логами.

Было:
```sh
$ mqtt-rpc-client -d wb_logs -s logs -m Load -a '{"limit":5,"service":"wb-mqtt-serial.service"}' | jq -r '.[].time'
1779454596461
1779454596421
1779454596363
1779454596321
1779454596260
$ mqtt-rpc-client -d wb_logs -s logs -m Load -a '{"limit":5,"service":"dmesg"}' | jq -r '.[].time' | head -n5
1778085513714
1778085513722
1778085513727
1778085513742
1778085513747
```

Стало:
```sh
$ mqtt-rpc-client -d wb_logs -s logs -m Load -a '{"limit":5,"service":"wb-mqtt-serial.service"}' | jq -r '.[].time'
1779469109383
1779469109289
1779469109283
1779469109190
1779469109184
$ mqtt-rpc-client -d wb_logs -s logs -m Load -a '{"limit":5,"service":"dmesg"}' | jq -r '.[].time' | head -n5
1779467480203
1779467480180
1779463291264
1779463291242
1779459072003
```

___________________________________
**Что поменялось для пользователей:**
dmesg лог отображается в ui в том же направлении как и остальные логи.

___________________________________
**Как проверял/а:**
на вб

